### PR TITLE
Narrower Tooltip Trigger

### DIFF
--- a/js/event-data.js
+++ b/js/event-data.js
@@ -2,7 +2,13 @@ const data = [
 	{
 		date: '18 Apr 1775',
 		eventName: "Paul Revere's Midnight Ride",
-		eventDescription: "Paul Revere rode to Lexington, MA, to warn of imminent British invasion.",
+		eventDescription: "Paul Revere rode from Charlestown (Boston) to Lexington, MA, to warn of British troop movement. Americans believed the British had orders to arrest John Hancock and Samuel Adams. The British planned to march to Concord, MA, to seize an arms stockpile.",
+		sharedOrPersonal: "Shared"
+	},
+	{
+		date: '19 Apr 1775',
+		eventName: "The Shot Heard Round the World",
+		eventDescription: "British troops met American militia around Lexington, MA. The American militia started to disperse. A shot was fired, and though it was unclear who fired the shot or whether it was intentional, the two sides started fighting.",
 		sharedOrPersonal: "Shared"
 	},
 	{

--- a/js/timeline.js
+++ b/js/timeline.js
@@ -28,14 +28,6 @@ function timeline() {
     }
   };
 
-  const labelSeparation = {
-    min: 12,
-    max: 48,
-    step: 2,
-    value: 24,
-    title: 'Label separation'
-  };
-
   const marker = {
     radius: 4
   };
@@ -59,7 +51,10 @@ function timeline() {
 
   function draw() {
     const containerWidth = parseInt(d3.select(selector).style('width'));
-    const containerHeight = parseInt(d3.select(selector).style('height'));
+    const containerHeight = d3.max([
+      parseInt(d3.select(selector).style('height')),
+      (1783 - 1775) * 150
+    ]);
     const width =
       containerWidth -
       spacingConfig.normalMargin.left -
@@ -164,7 +159,7 @@ function timeline() {
 
     const dodgedYValues = dodge(
       eventData.map((d) => y(d.date)),
-      labelSeparation
+      16
     );
 
     const eventLabels = plot
@@ -300,7 +295,10 @@ function timeline() {
       );
   }
 
-  function dodge(positions, separation = 10, maxiter = 10, maxerror = 1e-1) {
+  // The dodge function takes an array of positions (e.g. X values along an X Axis) in floating point numbers
+// The dodge function optionally takes customisable separation, iteration, and error values.
+// The dodge function returns a similar array of positions, but slightly dodged from where they were in an attempt to separate them out. It restrains the result a little bit so that the elements don't explode all over the place and so they don't go out of bounds.
+  function dodge(positions, separation = 100, maxiter = 10, maxerror = 1e-1) {
     // TODO: remove
     positions = Array.from(positions);
 

--- a/js/timeline.js
+++ b/js/timeline.js
@@ -233,7 +233,9 @@ function timeline() {
       const dodgedIndex = rangeY.indexOf(nearestEventY);
       const dataEvent = eventData[dodgedIndex];
 
-      if (mouseY >= rangeY0 - fuzzyTextHeightAdjustment) {
+      const distance = Math.abs(mouseY - nearestEventY);
+
+      if (mouseY >= rangeY0 - fuzzyTextHeightAdjustment && distance < 10) {
         eventLabels.filter((d, i) => i !== dodgedIndex).style('opacity', 0.3);
 
         eventLabels.filter((d, i) => i === dodgedIndex).style('opacity', 1);
@@ -269,6 +271,22 @@ function timeline() {
           .text(d3.timeFormat('%A, %e %B, %Y')(dataEvent.date));
         tooltip.select('#name').text(dataEvent.eventName);
         tooltip.select('#description').text(dataEvent.eventDescription);
+      } else {
+        markers
+          .attr('fill', (d) =>
+            d.sharedOrPersonal === 'Shared'
+              ? markerDefaultColor
+              : markerPersonalColor
+          )
+          .attr('stroke', (d) =>
+            d.sharedOrPersonal === 'Shared'
+              ? markerDefaultColor
+              : markerPersonalColor
+          );
+
+        eventLabels.style('opacity', 1);
+
+        tooltip.style('opacity', 0)
       }
     });
 

--- a/js/timeline.js
+++ b/js/timeline.js
@@ -271,7 +271,7 @@ function timeline() {
         );
         tooltip
           .select('#date')
-          .text(d3.timeFormat('%A, %e %B')(dataEvent.date));
+          .text(d3.timeFormat('%A, %e %B, %Y')(dataEvent.date));
         tooltip.select('#name').text(dataEvent.eventName);
         tooltip.select('#description').text(dataEvent.eventDescription);
       }


### PR DESCRIPTION
The point of this pull request is to only display the tooltip if the cursor is close to the event label.

It also:
- adds a data point
- adds logic to expand the graph height beyond the height of the screen
- fixes the logic to avoid placing events right on top of each other (the `dodge` was not called properly)
- copies more comments from the original Observable pen